### PR TITLE
Add API support for reverse proxy entries in Login Portal.

### DIFF
--- a/pkg/api/core/api.go
+++ b/pkg/api/core/api.go
@@ -75,4 +75,9 @@ type Api interface {
 	GroupModify(ctx context.Context, req GroupModifyRequest) (*GroupModifyResponse, error)
 	GroupDelete(ctx context.Context, req GroupDeleteRequest) (*GroupDeleteResponse, error)
 	GroupList(ctx context.Context) (*GroupListResponse, error)
+
+	ReverseProxyList(ctx context.Context) (*ReverseProxyListResponse, error)
+	ReverseProxyCreate(ctx context.Context, req ReverseProxyCreateRequest) (*ReverseProxyCreateResponse, error)
+	ReverseProxyModify(ctx context.Context, req ReverseProxyModifyRequest) (*ReverseProxyModifyResponse, error)
+	ReverseProxyDelete(ctx context.Context, req ReverseProxyDeleteRequest) (*ReverseProxyDeleteResponse, error)
 }

--- a/pkg/api/core/client.go
+++ b/pkg/api/core/client.go
@@ -673,6 +673,26 @@ func (c *Client) GroupDelete(
 	return api.Post[GroupDeleteResponse](c.client, ctx, &req, methods.GroupDelete)
 }
 
+// List reverse proxies
+func (c *Client) ReverseProxyList(ctx context.Context) (*ReverseProxyListResponse, error) {
+	return api.Post[ReverseProxyListResponse](c.client, ctx, &ReverseProxyListRequest{}, methods.ReverseProxyList)
+}
+
+// ReverseProxyCreate creates a new reverse proxy entry in login portal
+func (c *Client) ReverseProxyCreate(ctx context.Context, req ReverseProxyCreateRequest) (*ReverseProxyCreateResponse, error) {
+	return api.Post[ReverseProxyCreateResponse](c.client, ctx, &req, methods.ReverseProxyCreate)
+}
+
+// ReverseProxyModify modifies an existing reverse proxy entry.
+func (c *Client) ReverseProxyModify(ctx context.Context, req ReverseProxyModifyRequest) (*ReverseProxyModifyResponse, error) {
+	return api.Post[ReverseProxyModifyResponse](c.client, ctx, &req, methods.ReverseProxyModify)
+}
+
+// ReverseProxyDelete deletes an exisiting reverse proxy entry.
+func (c *Client) ReverseProxyDelete(ctx context.Context, req ReverseProxyDeleteRequest) (*ReverseProxyDeleteResponse, error) {
+	return api.Post[ReverseProxyDeleteResponse](c.client, ctx, &req, methods.ReverseProxyDelete)
+}
+
 func New(client api.Api) Api {
 	return &Client{client: client}
 }

--- a/pkg/api/core/methods/methods.go
+++ b/pkg/api/core/methods/methods.go
@@ -5,6 +5,7 @@ import (
 )
 
 const (
+	Core_AppPortal_ReverseProxy = "SYNO.Core.AppPortal.ReverseProxy"
 	Core_Event                  = "SYNO.Core.EventScheduler"
 	Core_Event_Root             = "SYNO.Core.EventScheduler.Root"
 	Core_Network                = "SYNO.Core.Network"
@@ -25,6 +26,31 @@ const (
 )
 
 var (
+	ReverseProxyList = api.Method{
+		API:            Core_AppPortal_ReverseProxy,
+		Version:        1,
+		Method:         api.MethodList,
+		ErrorSummaries: api.GlobalErrors,
+	}
+	ReverseProxyDelete = api.Method{
+		API:            Core_AppPortal_ReverseProxy,
+		Version:        1,
+		Method:         api.MethodDelete,
+		ErrorSummaries: api.GlobalErrors,
+	}
+	ReverseProxyCreate = api.Method{
+		API:            Core_AppPortal_ReverseProxy,
+		Version:        1,
+		Method:         api.MethodCreate,
+		ErrorSummaries: api.GlobalErrors,
+	}
+	ReverseProxyModify = api.Method{
+		API:            Core_AppPortal_ReverseProxy,
+		Version:        1,
+		Method:         api.MethodUpdate,
+		ErrorSummaries: api.GlobalErrors,
+	}
+
 	SystemInfo = api.Method{
 		API:            Core_System,
 		Version:        1,

--- a/pkg/api/core/reverse_proxy.go
+++ b/pkg/api/core/reverse_proxy.go
@@ -1,0 +1,86 @@
+package core
+
+type BackendProxy struct {
+	Fqdn     string `json:"fqdn"`
+	Port     int64  `json:"port"`
+	Protocol int64  `json:"protocol"`
+}
+
+type FrontendProxy struct {
+	Acl   *string `json:"acl"`
+	Fqdn  string  `json:"fqdn"`
+	Port  int64   `json:"port"`
+	Https struct {
+		Hsts bool `json:"hsts"`
+	} `json:"https"`
+	Protocol int64 `json:"protocol"`
+}
+
+type CustomHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type ReverseProxy struct {
+	UUID                 string         `json:"UUID"`
+	Key                  string         `json:"_key"`
+	Backend              BackendProxy   `json:"backend,omitempty"`
+	CustomizeHeaders     []CustomHeader `json:"customize_headers,omitempty"`
+	Description          string         `json:"description,omitempty"`
+	Frontend             FrontendProxy  `json:"frontend,omitempty"`
+	ProxyConnectTimeout  int64          `json:"proxy_connect_timeout"`
+	ProxyHttpVersion     int64          `json:"proxy_http_version,omitempty"`
+	ProxyInterceptErrors bool           `json:"proxy_intercept_errors,omitempty"`
+	ProxyReadTimeout     int64          `json:"proxy_read_timeout,omitempty"`
+	ProxySendTimeout     int64          `json:"proxy_send_timeout,omitempty"`
+}
+
+type ReverseProxyCreate struct {
+	Backend              map[string]any `json:"backend,omitempty"`
+	CustomizeHeaders     []CustomHeader `json:"customize_headers"`
+	Description          string         `json:"description,omitempty"`
+	Frontend             map[string]any `json:"frontend,omitempty"`
+	ProxyConnectTimeout  int64          `json:"proxy_connect_timeout"`
+	ProxyHttpVersion     int64          `json:"proxy_http_version,omitempty"`
+	ProxyInterceptErrors bool           `json:"proxy_intercept_errors"`
+	ProxyReadTimeout     int64          `json:"proxy_read_timeout,omitempty"`
+	ProxySendTimeout     int64          `json:"proxy_send_timeout,omitempty"`
+}
+type ReverseProxyModify struct {
+	ReverseProxyCreate
+	UUID string `json:"UUID"`
+	Key  string `json:"_key"`
+}
+
+type ReverseProxyListRequest struct {
+}
+
+type ReverseProxyListResponse struct {
+	Entries []ReverseProxy `json:"entries,omitempty"`
+}
+
+type ReverseProxyCreateRequest struct {
+	Entry      ReverseProxyCreate `url:"entry,json"`
+	Additional []string           `url:"additional,omitempty"`
+}
+
+// ReverseProxyCreateResponse for creating a reverse proxy entry
+type ReverseProxyCreateResponse struct {
+}
+
+// ReverseProxyDeleteRequest for deleting a reverse proxy entry
+type ReverseProxyDeleteRequest struct {
+	UUIDs []string `url:"uuids,json"`
+}
+
+// ReverseProxyDeleteResponse for deleting a reverse proxy entry
+type ReverseProxyDeleteResponse struct {
+}
+
+type ReverseProxyModifyRequest struct {
+	Entry ReverseProxyModify `url:"entry,json"`
+}
+
+// ReverseProxyModifyResponse for modifying a reverse proxy entry.
+type ReverseProxyModifyResponse struct {
+}


### PR DESCRIPTION
Basic API for listing/creating/modifying/deleting reverse proxies in Login Portal. Right now I don't use ACL so I'm not sure how they should be modeled but still sending the PR as it may prove usefule for other folks.