### PR TITLE
fix(api): prevent concurrent map writes in ErrorSummary.Combine

### DIFF
--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -644,11 +644,14 @@ var loginErrors ErrorSummaries = func() ErrorSummary {
 }
 
 func (es ErrorSummary) Combine(params ...ErrorSummary) ErrorSummary {
+	result := make(ErrorSummary, len(es))
+	maps.Copy(result, es)
+
 	for _, p := range params {
-		maps.Copy(es, p)
+		maps.Copy(result, p)
 	}
 
-	return es
+	return result
 }
 
 // ErrorDescriber defines interface to report all known errors to particular object.

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -245,6 +246,52 @@ func TestApiError_UnmarshalJSON_PreservesOtherFields(t *testing.T) {
 		[]ErrorFields{{Code: 407, Fields: map[string]any{"new": "value"}}},
 		apiError.Errors,
 	) // Should be updated
+}
+
+func TestErrorSummary_Combine_DoesNotMutateReceiver(t *testing.T) {
+	base := ErrorSummary{1: "one", 2: "two"}
+	extra := ErrorSummary{3: "three"}
+
+	result := base.Combine(extra)
+
+	// result should contain all entries
+	assert.Equal(t, ErrorSummary{1: "one", 2: "two", 3: "three"}, result)
+
+	// base must not be mutated
+	assert.Equal(t, ErrorSummary{1: "one", 2: "two"}, base)
+}
+
+func TestErrorSummary_Combine_OverlappingKeys(t *testing.T) {
+	base := ErrorSummary{1: "original", 2: "two"}
+	override := ErrorSummary{1: "overridden", 3: "three"}
+
+	result := base.Combine(override)
+
+	assert.Equal(t, ErrorSummary{1: "overridden", 2: "two", 3: "three"}, result)
+
+	// base must not be mutated
+	assert.Equal(t, ErrorSummary{1: "original", 2: "two"}, base)
+}
+
+// TestErrorSummary_Combine_ConcurrentSafe verifies that calling Combine on the
+// same ErrorSummary from multiple goroutines does not cause a concurrent map
+// write panic (regression test for https://github.com/synology-community/go-synology/issues/78).
+func TestErrorSummary_Combine_ConcurrentSafe(t *testing.T) {
+	base := GlobalErrors()
+	extra := ErrorSummary{99999: "custom"}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_ = base.Combine(extra)
+		}()
+	}
+
+	wg.Wait()
 }
 
 func TestApiError_UnmarshalJSON_ErrorHandling(t *testing.T) {

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -261,18 +261,6 @@ func TestErrorSummary_Combine_DoesNotMutateReceiver(t *testing.T) {
 	assert.Equal(t, ErrorSummary{1: "one", 2: "two"}, base)
 }
 
-func TestErrorSummary_Combine_OverlappingKeys(t *testing.T) {
-	base := ErrorSummary{1: "original", 2: "two"}
-	override := ErrorSummary{1: "overridden", 3: "three"}
-
-	result := base.Combine(override)
-
-	assert.Equal(t, ErrorSummary{1: "overridden", 2: "two", 3: "three"}, result)
-
-	// base must not be mutated
-	assert.Equal(t, ErrorSummary{1: "original", 2: "two"}, base)
-}
-
 // TestErrorSummary_Combine_ConcurrentSafe verifies that calling Combine on the
 // same ErrorSummary from multiple goroutines does not cause a concurrent map
 // write panic (regression test for https://github.com/synology-community/go-synology/issues/78).


### PR DESCRIPTION
## Summary

Fixes #78

`ErrorSummary.Combine` was mutating the receiver in-place via `maps.Copy`. Since `GlobalErrors()` returns a direct reference to the shared package-level `globalErrors` map, concurrent calls to `Combine` from multiple goroutines (e.g. Terraform refreshing several `synology_filestation_folder` resources in parallel) all write to the same map simultaneously, causing a fatal `concurrent map writes` panic.

## Fix

Copy the receiver into a new map before merging params, making `Combine` side-effect-free and safe for concurrent use:

```go
func (es ErrorSummary) Combine(params ...ErrorSummary) ErrorSummary {
    result := make(ErrorSummary, len(es))
    maps.Copy(result, es)

    for _, p := range params {
        maps.Copy(result, p)
    }

    return result
}
```

Note: this changes the semantics of `Combine` — it no longer mutates the receiver, so the returned value must always be used. All current callers already do this.

## Tests added

- `TestErrorSummary_Combine_DoesNotMutateReceiver` — verifies the original map is not modified
- `TestErrorSummary_Combine_ConcurrentSafe` — runs 20 goroutines calling `Combine` on `GlobalErrors()` simultaneously; passes cleanly under `-race`

## Alternative approach

The root cause is that `GlobalErrors()` returns the shared `globalErrors` map by reference. An alternative fix that preserves the original mutation semantics of `Combine` would be to return a copy from `GlobalErrors()` instead:

```go
var GlobalErrors ErrorSummaries = func() ErrorSummary {
    result := make(ErrorSummary, len(globalErrors))
    maps.Copy(result, globalErrors)
    return result // return a copy, not the shared map
}
```

With this approach `Combine` could keep mutating the receiver safely — it would always be working on a fresh copy, never on the shared map. The trade-off is a per-call allocation in `GlobalErrors()` vs. a per-call allocation in `Combine`. Happy to switch to this approach if preferred.