### PR TITLE
fix: skip JSON decoding for stream responses

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
@@ -591,6 +592,18 @@ func Do[T Response](
 }
 
 func handle[T Response](resp *http.Response, errorSummaries ErrorSummaries) (*T, error) {
+	var zero T
+	if _, ok := any(zero).(interface{ IsStream() }); ok {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		v := reflect.New(reflect.TypeOf(zero)).Elem()
+		v.SetString(string(body))
+		out := v.Interface().(T)
+		return &out, nil
+	}
+
 	var synoResponse ApiResponse[T]
 	var synoResponsePartialAuth ApiResponsePartialAuth[T]
 

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -1,7 +1,10 @@
 package api
 
+
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
@@ -9,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/synology-community/go-synology/pkg/api/docker"
 	"github.com/synology-community/go-synology/pkg/util"
 )
 
@@ -237,3 +241,30 @@ func TestHandleErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleStreamResponse(t *testing.T) {
+	expectedBody := "bar Pulling\nNetwork foo_default Creating\nExit Code: 0"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(expectedBody))
+	}))
+	defer server.Close()
+
+	c, err := New(Options{
+		Host:       server.URL,
+		VerifyCert: false,
+	})
+	require.NoError(t, err)
+
+	// We simulate the Do[T] flow by calling handle[T] directly
+	// since Do just calls handle.
+	resp, err := server.Client().Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Test with ProjectStreamResponse (which implements IsStream)
+	res, err := handle[docker.ProjectStreamResponse](resp, nil)
+	require.NoError(t, err)
+	assert.Equal(t, expectedBody, string(*res))
+}
+

--- a/pkg/api/docker/project.go
+++ b/pkg/api/docker/project.go
@@ -131,9 +131,11 @@ type ProjectCleanStreamRequest struct {
 }
 
 type ProjectCleanStreamResponse string
+func (ProjectCleanStreamResponse) IsStream() {}
 
 type ProjectStreamRequest struct {
 	ID string `url:"id,omitempty,quoted"`
 }
 
 type ProjectStreamResponse string
+func (ProjectStreamResponse) IsStream() {}


### PR DESCRIPTION
Add IsStream marker to project stream response types and update the API handler to bypass JSON decoding for types implementing this interface. This prevents "invalid character" errors when DSM returns raw plain-text docker compose output.

Fixes this issue:
https://github.com/synology-community/terraform-provider-synology/issues/177