### PR TITLE
fix: prevent race condition in GetQuery by copying base URL

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -498,15 +498,16 @@ func GetQuery[TResp any](c Api, ctx context.Context, r any, method Method) (*TRe
 		return nil, err
 	}
 
-	url := c.BaseUrl()
+	u2 := c.BaseUrl()
 
-	qu := maps.Clone(url.Query())
-	maps.Copy(aq, qu)
-	maps.Copy(aq, dq)
+	qu := maps.Clone(u2.Query())
+	maps.Copy(qu, aq)
+	maps.Copy(qu, dq)
 
-	u := c.BaseUrl()
+	u := new(url.URL)
+	*u = *u2
 
-	u.RawQuery = aq.Encode()
+	u.RawQuery = qu.Encode()
 
 	// Only set a timeout if one isn't already set
 	var cancel context.CancelFunc


### PR DESCRIPTION
## Summary

`GetQuery` mutates the shared `*url.URL` pointer returned by `BaseUrl()` instead of creating a local copy. When a consumer (e.g. a Terraform provider) refreshes multiple resources concurrently, goroutines overwrite each other's query parameters — causing resources to receive another resource's API response.

The `Get` function in the same file already handles this correctly by creating a local URL copy. This PR applies the same pattern to `GetQuery`.

## The Bug

```go
// GetQuery (before fix)
url := c.BaseUrl()           // shared pointer
qu := maps.Clone(url.Query())
maps.Copy(aq, qu)
maps.Copy(aq, dq)
u := c.BaseUrl()             // same shared pointer
u.RawQuery = aq.Encode()     // MUTATES shared URL — race condition
```

```go
// Get (already correct)
u2 := c.BaseUrl()
qu := maps.Clone(u2.Query())
maps.Copy(qu, aq)
maps.Copy(qu, dq)
u := new(url.URL)             // NEW local copy
*u = *u2
u.RawQuery = qu.Encode()      // modifies local copy only
```

## Race Scenario

1. Goroutine A (loading NFS share "configs"): sets `u.RawQuery` with `share_name=configs`
2. Goroutine B (loading NFS share "media"): overwrites `u.RawQuery` with `share_name=media`
3. Goroutine A calls `u.String()` → gets share "media"'s API response instead of "configs"

## Observed Symptoms

Discovered via `terraform-provider-synology-dsm` (which uses `GetQuery` for `synology_core_share_nfs_privilege` load/save):

- NFS privilege resources read back wrong rule count during state refresh
- `root_squash` values appear swapped between shares (e.g. `admin` ↔ `all_admin`)
- Non-deterministic — different shares affected on each `terraform plan` run
- Verified the DSM API returns correct data (all rules, correct values) — the corruption happens in the client

## Fix

Two changes to `GetQuery`, matching the pattern already used by `Get`:

1. **Create a local URL copy** (`u := new(url.URL); *u = *u2`) instead of mutating the shared base URL
2. **Fix `maps.Copy` direction** to match `Get`: `maps.Copy(qu, aq)` ensures method params override base URL params (not the reverse)