### PR TITLE
fix(api/core): support multipart OpenVPN client profile creation

### DIFF
--- a/pkg/api/core/api.go
+++ b/pkg/api/core/api.go
@@ -68,6 +68,11 @@ type Api interface {
 
 	NetworkGet(ctx context.Context) (*NetworkConfig, error)
 
+	OpenVPNClientProfileCreate(
+		ctx context.Context,
+		req OpenVPNClientProfileRequest,
+	) (*OpenVPNClientProfileResponse, error)
+
 	UserCreate(ctx context.Context, req UserCreateRequest) (*UserCreateResponse, error)
 	UserModify(ctx context.Context, req UserModifyRequest) (*UserModifyResponse, error)
 	UserDelete(ctx context.Context, req UserDeleteRequest) error

--- a/pkg/api/core/api.go
+++ b/pkg/api/core/api.go
@@ -72,6 +72,8 @@ type Api interface {
 		ctx context.Context,
 		req OpenVPNClientProfileRequest,
 	) (*OpenVPNClientProfileResponse, error)
+	OpenVPNClientProfileList(ctx context.Context) (*OpenVPNClientProfileListResponse, error)
+	OpenVPNClientProfileDelete(ctx context.Context, id string) error
 
 	UserCreate(ctx context.Context, req UserCreateRequest) (*UserCreateResponse, error)
 	UserModify(ctx context.Context, req UserModifyRequest) (*UserModifyResponse, error)

--- a/pkg/api/core/methods/methods.go
+++ b/pkg/api/core/methods/methods.go
@@ -5,25 +5,26 @@ import (
 )
 
 const (
-	Core_AppPortal_ReverseProxy = "SYNO.Core.AppPortal.ReverseProxy"
-	Core_Event                  = "SYNO.Core.EventScheduler"
-	Core_Event_Root             = "SYNO.Core.EventScheduler.Root"
-	Core_Network                = "SYNO.Core.Network"
-	Core_Package                = "SYNO.Core.Package"
-	Core_Package_Feed           = "SYNO.Core.Package.Feed"
-	Core_Package_Installation   = "SYNO.Core.Package.Installation"
-	Core_Package_Server         = "SYNO.Core.Package.Server"
-	Core_Package_Setting        = "SYNO.Core.Package.Setting"
-	Core_Package_Uninstallation = "SYNO.Core.Package.Uninstallation"
-	Core_Password_Confirm       = "SYNO.Core.User.PasswordConfirm"
-	Core_Share                  = "SYNO.Core.Share"
-	Core_Storage_Volume         = "SYNO.Core.Storage.Volume"
-	Core_System                 = "SYNO.Core.System"
-	Core_Task_Root              = "SYNO.Core.TaskScheduler.Root"
-	Core_TaskScheduler          = "SYNO.Core.TaskScheduler"
-	Core_Group                  = "SYNO.Core.Group"
-	Core_User                   = "SYNO.Core.User"
-	DSM_PortEnable              = "SYNO.DSM.PortEnable"
+	Core_AppPortal_ReverseProxy      = "SYNO.Core.AppPortal.ReverseProxy"
+	Core_Event                       = "SYNO.Core.EventScheduler"
+	Core_Event_Root                  = "SYNO.Core.EventScheduler.Root"
+	Core_Network                     = "SYNO.Core.Network"
+	Core_Network_VPN_OpenVPNWithConf = "SYNO.Core.Network.VPN.OpenVPNWithConf"
+	Core_Package                     = "SYNO.Core.Package"
+	Core_Package_Feed                = "SYNO.Core.Package.Feed"
+	Core_Package_Installation        = "SYNO.Core.Package.Installation"
+	Core_Package_Server              = "SYNO.Core.Package.Server"
+	Core_Package_Setting             = "SYNO.Core.Package.Setting"
+	Core_Package_Uninstallation      = "SYNO.Core.Package.Uninstallation"
+	Core_Password_Confirm            = "SYNO.Core.User.PasswordConfirm"
+	Core_Share                       = "SYNO.Core.Share"
+	Core_Storage_Volume              = "SYNO.Core.Storage.Volume"
+	Core_System                      = "SYNO.Core.System"
+	Core_Task_Root                   = "SYNO.Core.TaskScheduler.Root"
+	Core_TaskScheduler               = "SYNO.Core.TaskScheduler"
+	Core_Group                       = "SYNO.Core.Group"
+	Core_User                        = "SYNO.Core.User"
+	DSM_PortEnable                   = "SYNO.DSM.PortEnable"
 )
 
 var (
@@ -338,6 +339,12 @@ var (
 		API:            Core_Network,
 		Version:        2,
 		Method:         api.MethodGet,
+		ErrorSummaries: api.GlobalErrors,
+	}
+	NetworkVPNOpenVPNWithConfCreate = api.Method{
+		API:            Core_Network_VPN_OpenVPNWithConf,
+		Version:        1,
+		Method:         api.MethodCreate,
 		ErrorSummaries: api.GlobalErrors,
 	}
 )

--- a/pkg/api/core/methods/methods.go
+++ b/pkg/api/core/methods/methods.go
@@ -347,4 +347,16 @@ var (
 		Method:         api.MethodCreate,
 		ErrorSummaries: api.GlobalErrors,
 	}
+	NetworkVPNOpenVPNWithConfList = api.Method{
+		API:            Core_Network_VPN_OpenVPNWithConf,
+		Version:        1,
+		Method:         api.MethodList,
+		ErrorSummaries: api.GlobalErrors,
+	}
+	NetworkVPNOpenVPNWithConfDelete = api.Method{
+		API:            Core_Network_VPN_OpenVPNWithConf,
+		Version:        1,
+		Method:         api.MethodDelete,
+		ErrorSummaries: api.GlobalErrors,
+	}
 )

--- a/pkg/api/core/vpn.go
+++ b/pkg/api/core/vpn.go
@@ -35,6 +35,9 @@ type OpenVPNClientProfileRequest struct {
 	Reconnect      bool      `form:"reconnect"`
 }
 
+// DSM's create response carries no useful data (not even the new profile's
+// id) — confirmed empirically, so the id must be discovered afterwards via
+// OpenVPNClientProfileList.
 type OpenVPNClientProfileResponse struct{}
 
 func (c *Client) OpenVPNClientProfileCreate(
@@ -46,5 +49,57 @@ func (c *Client) OpenVPNClientProfileCreate(
 		ctx,
 		&req,
 		methods.NetworkVPNOpenVPNWithConfCreate,
+	)
+}
+
+// OpenVPNClientProfile is a single profile entry as returned by
+// SYNO.Core.Network.VPN.OpenVPNWithConf, method list.
+type OpenVPNClientProfile struct {
+	ID             string `json:"id"`
+	ConfigName     string `json:"confname"`
+	User           string `json:"user"`
+	Server         string `json:"server"`
+	DefaultGateway bool   `json:"defgw"`
+	NAT            bool   `json:"nat"`
+	Reconnect      bool   `json:"reconnect"`
+	Protocol       string `json:"prtl"`
+	Status         string `json:"status,omitempty"`
+}
+
+type OpenVPNClientProfileListRequest struct {
+	Additional []string `url:"additional,omitempty,json"`
+}
+
+type OpenVPNClientProfileListResponse []OpenVPNClientProfile
+
+// OpenVPNClientProfileList lists all OpenVPN client profiles configured on
+// the DSM VPN Client. Use this to discover a profile's id (needed for
+// OpenVPNClientProfileDelete), since create doesn't return it.
+func (c *Client) OpenVPNClientProfileList(
+	ctx context.Context,
+) (*OpenVPNClientProfileListResponse, error) {
+	return api.Get[OpenVPNClientProfileListResponse](
+		c.client,
+		ctx,
+		&OpenVPNClientProfileListRequest{Additional: []string{"status"}},
+		methods.NetworkVPNOpenVPNWithConfList,
+	)
+}
+
+// OpenVPNClientProfileDeleteRequest deletes a profile by id (e.g.
+// "o1786051381"), as returned by OpenVPNClientProfileList.
+type OpenVPNClientProfileDeleteRequest struct {
+	ID string `url:"id,quoted"`
+}
+
+// OpenVPNClientProfileDelete deletes an existing OpenVPN client profile.
+// Endpoint: SYNO.Core.Network.VPN.OpenVPNWithConf, method delete. Like
+// create, this is undocumented; captured from DSM's own VPN Client UI.
+func (c *Client) OpenVPNClientProfileDelete(ctx context.Context, id string) error {
+	return api.Void(
+		c.client,
+		ctx,
+		&OpenVPNClientProfileDeleteRequest{ID: id},
+		methods.NetworkVPNOpenVPNWithConfDelete,
 	)
 }

--- a/pkg/api/core/vpn.go
+++ b/pkg/api/core/vpn.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"context"
+
+	"github.com/synology-community/go-synology/pkg/api"
+	"github.com/synology-community/go-synology/pkg/api/core/methods"
+	"github.com/synology-community/go-synology/pkg/util/form"
+)
+
+// OpenVPNClientProfileRequest creates an OpenVPN client connection profile on
+// the DSM VPN Client from an imported .ovpn configuration file.
+//
+// Endpoint: SYNO.Core.Network.VPN.OpenVPNWithConf, method create. This API is
+// undocumented; its field names and multipart/form-data shape were captured
+// from the request DSM's own "Create VPN Profile" wizard sends (it is not a
+// regular JSON-parameter API call like most SYNO.Core.* endpoints).
+type OpenVPNClientProfileRequest struct {
+	ConfigName     string    `form:"confname"`
+	Server         string    `form:"server"`
+	User           string    `form:"user"`
+	Pass           string    `form:"pass"`
+	PresharedKey   string    `form:"preshared_key"`
+	Port           string    `form:"port"`
+	Protocol       string    `form:"protocol"`
+	OVPNFile       form.File `form:"ovpn_file"       kind:"file"`
+	CAFile         form.File `form:"ca_file"         kind:"file"`
+	ClientCrtFile  form.File `form:"client_crt_file" kind:"file"`
+	ClientKeyFile  form.File `form:"client_key_file" kind:"file"`
+	PemFile        form.File `form:"pem_file"        kind:"file"`
+	TAFile         form.File `form:"ta_file"         kind:"file"`
+	Compress       string    `form:"compress"`
+	DefaultGateway bool      `form:"defgw"`
+	NAT            bool      `form:"nat"`
+	Reconnect      bool      `form:"reconnect"`
+}
+
+type OpenVPNClientProfileResponse struct{}
+
+func (c *Client) OpenVPNClientProfileCreate(
+	ctx context.Context,
+	req OpenVPNClientProfileRequest,
+) (*OpenVPNClientProfileResponse, error) {
+	return api.PostFileWithQuery[OpenVPNClientProfileResponse](
+		c.client,
+		ctx,
+		&req,
+		methods.NetworkVPNOpenVPNWithConfCreate,
+	)
+}

--- a/pkg/api/core/vpn_test.go
+++ b/pkg/api/core/vpn_test.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/synology-community/go-synology/pkg/util/form"
+)
+
+func TestOpenVPNClientProfileRequest_Marshal(t *testing.T) {
+	req := OpenVPNClientProfileRequest{
+		ConfigName:     "pornic",
+		User:           "freebox-pornic",
+		Pass:           "s3cr3t",
+		PresharedKey:   "s3cr3t",
+		Port:           "1194",
+		Protocol:       "udp",
+		OVPNFile:       form.File{Name: "perreux.ovpn", Content: "client\nremote 1.2.3.4 1194\n"},
+		DefaultGateway: true,
+		NAT:            true,
+		Reconnect:      true,
+	}
+
+	buf := new(bytes.Buffer)
+	w, _, err := form.Marshal(buf, &req)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	r := multipart.NewReader(buf, w.Boundary())
+
+	fields := map[string]string{}
+	files := map[string]string{}
+	for {
+		part, err := r.NextPart()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+
+		name := part.FormName()
+		content, err := io.ReadAll(part)
+		require.NoError(t, err)
+
+		if strings.Contains(part.Header.Get("Content-Disposition"), "filename=") {
+			files[name] = string(content)
+		} else {
+			fields[name] = string(content)
+		}
+	}
+
+	require.Equal(t, "pornic", fields["confname"])
+	require.Equal(t, "", fields["server"])
+	require.Equal(t, "freebox-pornic", fields["user"])
+	require.Equal(t, "s3cr3t", fields["pass"])
+	require.Equal(t, "s3cr3t", fields["preshared_key"])
+	require.Equal(t, "1194", fields["port"])
+	require.Equal(t, "udp", fields["protocol"])
+	require.Equal(t, "true", fields["defgw"])
+	require.Equal(t, "true", fields["nat"])
+	require.Equal(t, "true", fields["reconnect"])
+
+	require.Equal(t, "client\nremote 1.2.3.4 1194\n", files["ovpn_file"])
+	// Unused file slots are still sent as empty parts, matching what DSM's own
+	// "Create VPN Profile" wizard sends.
+	require.Contains(t, files, "ca_file")
+	require.Contains(t, files, "client_crt_file")
+	require.Contains(t, files, "client_key_file")
+	require.Contains(t, files, "pem_file")
+	require.Contains(t, files, "ta_file")
+}

--- a/pkg/api/core/vpn_test.go
+++ b/pkg/api/core/vpn_test.go
@@ -2,12 +2,14 @@ package core
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/synology-community/go-synology/pkg/query"
 	"github.com/synology-community/go-synology/pkg/util/form"
 )
 
@@ -71,4 +73,49 @@ func TestOpenVPNClientProfileRequest_Marshal(t *testing.T) {
 	require.Contains(t, files, "client_key_file")
 	require.Contains(t, files, "pem_file")
 	require.Contains(t, files, "ta_file")
+}
+
+func TestOpenVPNClientProfileListRequest_EncodeValues(t *testing.T) {
+	req := OpenVPNClientProfileListRequest{Additional: []string{"status"}}
+
+	v, err := query.Values(&req)
+	require.NoError(t, err)
+
+	require.Contains(t, v.Encode(), "additional=%5B%22status%22%5D")
+}
+
+func TestOpenVPNClientProfileDeleteRequest_EncodeValues(t *testing.T) {
+	req := OpenVPNClientProfileDeleteRequest{ID: "o1786051381"}
+
+	v, err := query.Values(&req)
+	require.NoError(t, err)
+
+	require.Equal(t, "id=%22o1786051381%22", v.Encode())
+}
+
+func TestOpenVPNClientProfileListResponse_Unmarshal(t *testing.T) {
+	// Captured from the "data" field of a real
+	// SYNO.Core.Network.VPN.OpenVPNWithConf list response; the outer
+	// {"data": ..., "success": true} envelope is unwrapped by the client's
+	// handle() before decoding into TResp, so only the inner array is
+	// exercised here.
+	body := []byte(
+		`[{"confname":"perreux","defgw":false,"id":"o1786140031","nat":true,"pass":"\t\t\t\t\t\t\t\t","prtl":"ovpn_conf","reconnect":true,"rx":"0","server":"82.64.94.63","status":"connected","tx":"0","uptime":"114","user":"perreux","virtual_ip":"192.168.27.66","vpn_gateway":"212.27.38.253"}]`,
+	)
+
+	var resp OpenVPNClientProfileListResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+
+	require.Len(t, resp, 1)
+
+	profile := resp[0]
+	require.Equal(t, "o1786140031", profile.ID)
+	require.Equal(t, "perreux", profile.ConfigName)
+	require.Equal(t, "perreux", profile.User)
+	require.Equal(t, "82.64.94.63", profile.Server)
+	require.False(t, profile.DefaultGateway)
+	require.True(t, profile.NAT)
+	require.True(t, profile.Reconnect)
+	require.Equal(t, "ovpn_conf", profile.Protocol)
+	require.Equal(t, "connected", profile.Status)
 }


### PR DESCRIPTION
## Summary
- `SYNO.Core.Network.VPN.OpenVPNWithConf` `create` requires a `multipart/form-data` POST with several file parts (`ovpn_file`, `ca_file`, `client_crt_file`, `client_key_file`, `pem_file`, `ta_file`), unlike most other `SYNO.Core.*` endpoints which take plain JSON/query-string parameters.
- Adds `core.Client.OpenVPNClientProfileCreate`, modeled on the existing `PackageInstallUpload`/`filestation.Upload` multipart patterns (`api.PostFileWithQuery` + `form.Marshal`).
- Field names and request shape were captured directly from the request DSM's own "Create VPN Profile" wizard sends in the browser, since this API is undocumented.

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] New unit test `TestOpenVPNClientProfileRequest_Marshal` verifies the multipart body encodes the expected field names/values (no network access required)
- [x] Full test suite run, confirmed only pre-existing integration tests requiring live NAS credentials fail (unrelated to this change)