### PR TITLE
fix(core): send enable=false for tasks instead of dropping it

### DIFF
--- a/pkg/api/core/task.go
+++ b/pkg/api/core/task.go
@@ -29,7 +29,7 @@ type TaskRequest struct {
 	Schedule           TaskSchedule `url:"schedule,json,omitempty"      json:"schedule,omitempty"`
 	Extra              TaskExtra    `url:"extra,json,omitempty"         json:"extra,omitempty"`
 	Type               string       `url:"type,omitempty"               json:"type,omitempty"`
-	Enable             bool         `url:"enable,omitempty"             json:"enable,omitempty"`
+	Enable             bool         `url:"enable"                       json:"enable,omitempty"`
 	ID                 *int64       `url:"id,omitempty"                 json:"id,omitempty"`
 	SynoConfirmPWToken string       `url:"SynoConfirmPWToken,omitempty" json:"SynoConfirmPWToken,omitempty"`
 }

--- a/pkg/api/core/task_test.go
+++ b/pkg/api/core/task_test.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/synology-community/go-synology/pkg/query"
+)
+
+// PLAT-522: TaskRequest.Enable must reach the wire as an explicit
+// enable=false, not be dropped, so a plan that disables an already-enabled
+// task can actually take effect. `omitempty` on a bool field causes the
+// go-querystring encoder to silently drop `false` values entirely, which
+// previously made disabling a task impossible.
+func TestTaskRequest_EncodeValues_EnableFalse(t *testing.T) {
+	req := TaskRequest{
+		Name:   "test",
+		Enable: false,
+	}
+
+	v, err := query.Values(req)
+	if err != nil {
+		t.Fatalf("query.Values() error = %v", err)
+	}
+
+	if got := v.Get("enable"); got != "false" {
+		t.Errorf("TaskRequest.EncodeValues() enable = %q, want %q", got, "false")
+	}
+
+	encoded := v.Encode()
+	if !strings.Contains(encoded, "enable=false") {
+		t.Errorf("TaskRequest.EncodeValues() encoded = %q, want it to contain %q", encoded, "enable=false")
+	}
+}
+
+// TestTaskRequest_EncodeValues_EnableTrue guards the other direction: a
+// true value must still be sent (this passed before the fix too, but is
+// worth pinning so a future regression can't flip both cases silently).
+func TestTaskRequest_EncodeValues_EnableTrue(t *testing.T) {
+	req := TaskRequest{
+		Name:   "test",
+		Enable: true,
+	}
+
+	v, err := query.Values(req)
+	if err != nil {
+		t.Fatalf("query.Values() error = %v", err)
+	}
+
+	encoded := v.Encode()
+	if !strings.Contains(encoded, "enable=true") {
+		t.Errorf("TaskRequest.EncodeValues() encoded = %q, want it to contain %q", encoded, "enable=true")
+	}
+}


### PR DESCRIPTION
## The problem

`TaskRequest.Enable` is tagged `url:"enable,omitempty"`, and requests are form-encoded with `go-querystring`, where `omitempty` drops a `false` bool entirely:

| Tag | `Enable=false` encodes as |
| --- | --- |
| `url:"enable,omitempty"` | `name=t` — **parameter absent** |
| `url:"enable"` | `enable=false&name=t` |

So the field can express "enabled" but never "disabled". Creating a disabled task appears to work only by coincidence — DSM's own default is disabled — while **disabling an existing enabled task is impossible**, because the parameter never reaches DSM at all.

This blocks any consumer that wants to manage a task's enabled state, notably `terraform-provider-synology`'s `synology_core_task`, which cannot offer a meaningful `enable` attribute while the client can only ever say `true`.

## The change

Drop `omitempty` from the `url` tag so the value is always transmitted.

The `json` tag is deliberately left alone: `TaskRequest` is never `json.Marshal`ed — every caller routes through `api.Post` → `postEntry` → `query.Values`, which reads the `url` tag only — so that tag is inert for this struct's request path.

## The test

It asserts the **encoded form**, not the struct field. A test checking `req.Enable == false` passes throughout this defect's life, which is presumably why it went unnoticed; this one calls `query.Values` and asserts the output contains `enable=false`.

## Audit

`Enable` is the only bool in `task.go` whose `false` is both meaningful and `omitempty`-tagged on a request struct. `ID` is a pointer (nil correctly means "don't send"), `TaskExtra`'s bools carry json-only tags inside the nested blob, and `TaskResult`'s bools are response fields, where `omitempty` never affects unmarshalling.

## Verification

Unit test as above, plus verified against a live **DSM 7.3.2-86009 (DS1621+)**: with this change a task can be disabled through the API and reads back `enable: False`; without it the request carries no `enable` parameter and the task stays enabled.