### PR TITLE
feat(core,docker): ShareModify, container get/list/delete, registry create/delete

### DIFF
--- a/pkg/api/core/api.go
+++ b/pkg/api/core/api.go
@@ -40,6 +40,7 @@ type Api interface {
 	ShareGet(ctx context.Context, name string) (*ShareGetResponse, error)
 	ShareGetByID(ctx context.Context, id string) (*Share, error)
 	ShareCreate(ctx context.Context, share ShareInfo) error
+	ShareModify(ctx context.Context, req ShareModifyRequest) error
 	ShareDelete(ctx context.Context, name string) error
 	VolumeList(ctx context.Context) (*VolumeListResponse, error)
 

--- a/pkg/api/core/client.go
+++ b/pkg/api/core/client.go
@@ -463,6 +463,10 @@ func (c Client) ShareCreate(ctx context.Context, share ShareInfo) error {
 	}, methods.ShareCreate)
 }
 
+func (c Client) ShareModify(ctx context.Context, req ShareModifyRequest) error {
+	return api.Void(c.client, ctx, &req, methods.ShareModify)
+}
+
 func (c Client) ShareDelete(ctx context.Context, name string) error {
 	return api.Void(c.client, ctx, &ShareDeleteRequest{
 		Name: name,
@@ -612,7 +616,7 @@ func (c *Client) TaskRun(ctx context.Context, ids ...int64) error {
 
 func (c *Client) UserList(ctx context.Context) (*UserListResponse, error) {
 	return api.Get[UserListResponse](c.client, ctx, &UserListRequest{
-		Additional: []string{"uid"},
+		Additional: []string{"uid", "email", "description", "expired"},
 	}, methods.UserList)
 }
 
@@ -643,7 +647,9 @@ func (c *Client) UserDelete(ctx context.Context, req UserDeleteRequest) error {
 
 // GroupList lists all groups.
 func (c *Client) GroupList(ctx context.Context) (*GroupListResponse, error) {
-	return api.Get[GroupListResponse](c.client, ctx, &GroupListRequest{}, methods.GroupList)
+	return api.Get[GroupListResponse](c.client, ctx, &GroupListRequest{
+		Additional: []string{"name", "description", "gid"},
+	}, methods.GroupList)
 }
 
 // GroupCreate creates a new group.

--- a/pkg/api/core/group.go
+++ b/pkg/api/core/group.go
@@ -9,7 +9,8 @@ type Group struct {
 
 // GroupListRequest for listing groups.
 type GroupListRequest struct {
-	Additional []string `url:"additional,omitempty"`
+	// DSM expects a JSON array string, not repeated form fields.
+	Additional []string `url:"additional,json,omitempty"`
 }
 
 // GroupListResponse for listing groups.

--- a/pkg/api/core/methods/methods.go
+++ b/pkg/api/core/methods/methods.go
@@ -172,6 +172,12 @@ var (
 		Method:         api.MethodDelete,
 		ErrorSummaries: api.GlobalErrors,
 	}
+	ShareModify = api.Method{
+		API:            Core_Share,
+		Version:        1,
+		Method:         api.MethodSet,
+		ErrorSummaries: api.GlobalErrors,
+	}
 	VolumeList = api.Method{
 		API:            Core_Storage_Volume,
 		Version:        1,

--- a/pkg/api/core/share.go
+++ b/pkg/api/core/share.go
@@ -67,6 +67,9 @@ type ShareInfo struct {
 	Name                string `json:"name,omitempty"`
 	VolPath             string `json:"vol_path,omitempty"`
 	Desc                string `json:"desc,omitempty"`
+	Hidden              bool   `json:"hidden,omitempty"`
+	EnableRecycleBin    bool   `json:"enable_recycle_bin,omitempty"`
+	RecycleBinAdminOnly bool   `json:"recycle_bin_admin_only,omitempty"`
 	EnableShareCow      bool   `json:"enable_share_cow,omitempty"`
 	EnableShareCompress bool   `json:"enable_share_compress,omitempty"`
 	NameOrg             string `json:"name_org,omitempty"`
@@ -79,4 +82,10 @@ type ShareCreateRequest struct {
 
 type ShareDeleteRequest struct {
 	Name string `url:"name"`
+}
+
+// ShareModifyRequest updates an existing shared folder via SYNO.Core.Share method set.
+type ShareModifyRequest struct {
+	Name      string    `url:"name"`
+	ShareInfo ShareInfo `url:"shareinfo,json"`
 }

--- a/pkg/api/core/user.go
+++ b/pkg/api/core/user.go
@@ -17,7 +17,8 @@ type User struct {
 }
 
 type UserListRequest struct {
-	Additional []string `url:"additional,omitempty"`
+	// DSM expects a JSON array string, not repeated form fields.
+	Additional []string `url:"additional,json,omitempty"`
 }
 
 type UserListResponse struct {

--- a/pkg/api/docker/api.go
+++ b/pkg/api/docker/api.go
@@ -9,6 +9,9 @@ type Api interface {
 		ctx context.Context,
 		container CreateContainerRequest,
 	) (*CreateContainerResponse, error)
+	ContainerGet(ctx context.Context, name string) (*ContainerGetResponse, error)
+	ContainerList(ctx context.Context, req ContainerListRequest) (*ContainerListResponse, error)
+	ContainerDelete(ctx context.Context, req ContainerDeleteRequest) error
 	ContainerStop(
 		ctx context.Context,
 		req ContainerOperationRequest,
@@ -23,6 +26,8 @@ type Api interface {
 	) (*ContainerRestartResponse, error)
 
 	RegistryList(ctx context.Context, req ListRegistryRequest) (*ListRegistryResponse, error)
+	RegistryCreate(ctx context.Context, req RegistryCreateRequest) error
+	RegistryDelete(ctx context.Context, req RegistryDeleteRequest) error
 
 	ImagePullStart(ctx context.Context, req ImagePullStartRequest) (*ImagePullStartResponse, error)
 	ImagePullStatus(

--- a/pkg/api/docker/client.go
+++ b/pkg/api/docker/client.go
@@ -186,6 +186,29 @@ func (d *Client) ContainerCreate(
 	return api.Post[CreateContainerResponse](d.client, ctx, &req, methods.Create)
 }
 
+// ContainerGet implements DockerApi.
+func (d *Client) ContainerGet(ctx context.Context, name string) (*ContainerGetResponse, error) {
+	return api.Post[ContainerGetResponse](d.client, ctx, &ContainerGetRequest{
+		Name: name,
+	}, methods.Get)
+}
+
+// ContainerList implements DockerApi.
+func (d *Client) ContainerList(
+	ctx context.Context,
+	req ContainerListRequest,
+) (*ContainerListResponse, error) {
+	if req.Limit == 0 {
+		req.Limit = -1
+	}
+	return api.Post[ContainerListResponse](d.client, ctx, &req, methods.List)
+}
+
+// ContainerDelete implements DockerApi.
+func (d *Client) ContainerDelete(ctx context.Context, req ContainerDeleteRequest) error {
+	return api.PostVoid(d.client, ctx, &req, methods.Delete)
+}
+
 // ContainerStop implements DockerApi.
 func (d *Client) ContainerStop(
 	ctx context.Context,
@@ -216,6 +239,16 @@ func (d *Client) RegistryList(
 	req ListRegistryRequest,
 ) (*ListRegistryResponse, error) {
 	return api.Post[ListRegistryResponse](d.client, ctx, &req, methods.RegistryList)
+}
+
+// RegistryCreate implements DockerApi.
+func (d *Client) RegistryCreate(ctx context.Context, req RegistryCreateRequest) error {
+	return api.PostVoid(d.client, ctx, &req, methods.RegistryCreate)
+}
+
+// RegistryDelete implements DockerApi.
+func (d *Client) RegistryDelete(ctx context.Context, req RegistryDeleteRequest) error {
+	return api.PostVoid(d.client, ctx, &req, methods.RegistryDelete)
 }
 
 // NetworkList implements DockerApi.

--- a/pkg/api/docker/container.go
+++ b/pkg/api/docker/container.go
@@ -91,3 +91,43 @@ type (
 type (
 	ContainerRestartResponse = ContainerOperationResponse
 )
+
+// ContainerListRequest lists containers. DSM requires limit/offset; -1 means all.
+type ContainerListRequest struct {
+	Limit  int64 `url:"limit"`
+	Offset int64 `url:"offset"`
+}
+
+// ContainerListItem is one row from SYNO.Docker.Container list.
+// Only fields the provider needs are typed; DSM also returns nested State and
+// NetworkSettings objects which json.Unmarshal ignores when untyped here.
+type ContainerListItem struct {
+	ID     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Image  string `json:"image,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// ContainerListResponse is the list payload.
+type ContainerListResponse struct {
+	Containers []ContainerListItem `json:"containers,omitempty"`
+}
+
+// ContainerGetRequest fetches one container by name.
+type ContainerGetRequest struct {
+	Name string `url:"name"`
+}
+
+// ContainerGetResponse holds the live profile and docker details for a container.
+type ContainerGetResponse struct {
+	Profile Container      `json:"profile,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// ContainerDeleteRequest removes a container by name.
+// Name is quoted like start/stop. Force is sent as a JSON boolean string
+// (json.dumps style) which is what the community Python client uses.
+type ContainerDeleteRequest struct {
+	Name  string `url:"name,quoted"`
+	Force bool   `url:"force"`
+}

--- a/pkg/api/docker/methods/methods.go
+++ b/pkg/api/docker/methods/methods.go
@@ -64,6 +64,18 @@ var (
 		Method:         api.MethodGet,
 		ErrorSummaries: CommonErrors,
 	}
+	RegistryCreate = api.Method{
+		API:            API_DockerRegistry,
+		Version:        1,
+		Method:         api.MethodCreate,
+		ErrorSummaries: CommonErrors,
+	}
+	RegistryDelete = api.Method{
+		API:            API_DockerRegistry,
+		Version:        1,
+		Method:         api.MethodDelete,
+		ErrorSummaries: CommonErrors,
+	}
 	ImagePullStart = api.Method{
 		API:            API_DockerImage,
 		Version:        1,

--- a/pkg/api/docker/registry.go
+++ b/pkg/api/docker/registry.go
@@ -20,3 +20,15 @@ type ListRegistryRequest struct {
 	Limit  int64 `json:"limit,omitempty"`
 	Offset int64 `json:"offset,omitempty"`
 }
+
+// RegistryCreateRequest adds a third-party registry (name + url).
+type RegistryCreateRequest struct {
+	Name           string `url:"name"`
+	URL            string `url:"url"`
+	EnableTrustSSC *bool  `url:"enable_trust_SSC,omitempty"`
+}
+
+// RegistryDeleteRequest removes a registry by name.
+type RegistryDeleteRequest struct {
+	Name string `url:"name"`
+}


### PR DESCRIPTION
## Summary

Adds client methods needed for declarative management of DSM shared folders, standalone containers, and third-party registries:

- **Core:** `ShareModify` (`SYNO.Core.Share` method `set`), JSON-encoded `additional` on `UserList` / `GroupList`
- **Docker:** `ContainerGet`, `ContainerList`, `ContainerDelete` (wrappers for existing method constants)
- **Docker:** `RegistryCreate`, `RegistryDelete`

## Context

Probed on DSM 7.3 (DS1621+). Share `set` succeeds after create. Registry create/delete work with `name` + `url`. Container get/list work with `limit`/`offset`; delete currently returns DSM 114 for every known parameter shape on our test host (create/start/stop still work) — the client surface is still useful and matches the method table.

## Test plan

- [ ] Unit / compile: `go build ./pkg/api/...`
- [ ] Optional live NAS: create share, set desc, delete; create registry, delete; list containers